### PR TITLE
Multi Query null check

### DIFF
--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -82,7 +82,8 @@ namespace InfluxData.Net.InfluxDb.ClientModules
                     throw new InfluxDbApiException(HttpStatusCode.BadRequest, result.Error);
                 }
 
-                series.AddRange(result.Series);
+                // multi-queries can have results that are empty (just like handled in single QueryAsync)
+                series.AddRange(result.Series ?? new Serie[0]);
             }
 
             return series;


### PR DESCRIPTION
Needs the same null series check as single query method.

I know it looks like you LITERALLY just implemented this, but needed to use immediately anyways.