### PR TITLE
Fixed ToUnixTime method

### DIFF
--- a/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
+++ b/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
@@ -43,7 +43,7 @@ namespace InfluxData.Net.Common.Helpers
         /// <returns>Unix-style timestamp in milliseconds.</returns>
         public static long ToUnixTime(this DateTime date)
         {
-            return Convert.ToInt64((date - _epoch).Milliseconds);
+            return Convert.ToInt64((date - _epoch).TotalMilliseconds);
         }
 
         /// <summary>


### PR DESCRIPTION
Your ToUnixTime method didn't return total milliseconds since epoch. Points with the Timestamp property written to InfluxDB had a timestamp on epoch.