### PR TITLE
Add ConfigureAwait to asynchronous calls that were failing when runni…

### DIFF
--- a/InfluxData.Net.Common/RequestClients/RequestClientBase.cs
+++ b/InfluxData.Net.Common/RequestClients/RequestClientBase.cs
@@ -45,13 +45,13 @@ namespace InfluxData.Net.Common.RequestClients
                 path,
                 requestParams,
                 content,
-                includeAuthToQuery);
+                includeAuthToQuery).ConfigureAwait(false);
 
             string responseContent = String.Empty;
 
             if (!headerIsBody)
             {
-                responseContent = await response.Content.ReadAsStringAsync();
+                responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
             else
             {
@@ -105,7 +105,7 @@ namespace InfluxData.Net.Common.RequestClients
             }
 #endif
 
-            return await client.SendAsync(request, completionOption, cancellationToken);
+            return await client.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion Request Base

--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -24,14 +24,14 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds)
         {
-            var response = await WriteAsync(dbName, new [] { point }, retenionPolicy, precision);
+            var response = await WriteAsync(dbName, new [] { point }, retenionPolicy, precision).ConfigureAwait(false);
 
             return response;
         }
 
         public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds)
         {
-            var request = new WriteRequest(this.RequestClient.GetPointFormatter())
+            var request = new WriteRequest(RequestClient.GetPointFormatter())
             {
                 DbName = dbName,
                 Points = points,
@@ -39,31 +39,29 @@ namespace InfluxData.Net.InfluxDb.ClientModules
                 Precision = precision.GetParamValue()
             };
 
-            var response = await this.RequestClient.PostAsync(request);
+            var response = await RequestClient.PostAsync(request).ConfigureAwait(false);
 
             return response;
         }
 
         public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, string query)
         {
-            var response = await base.RequestClient.QueryAsync(dbName, query);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query);
-
+            var response = await RequestClient.QueryAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
             return series;
         }
 
         public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries)
         {
-            var response = await base.RequestClient.QueryAsync(dbName, queries.ToSemicolonSpaceSeparatedString());
+            var response = await RequestClient.QueryAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
             var results = response.ReadAs<QueryResponse>().Validate().Results;
             var series = _basicResponseParser.FlattenResultsSeries(results);
-
             return series;
         }
 
         public virtual async Task<IEnumerable<IEnumerable<Serie>>> MultiQueryAsync(string dbName, IEnumerable<string> queries)
         {
-            var response = await base.RequestClient.QueryAsync(dbName, queries.ToSemicolonSpaceSeparatedString());
+            var response = await RequestClient.QueryAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
             var results = response.ReadAs<QueryResponse>().Validate().Results;
             var resultSeries = _basicResponseParser.MapResultsSeries(results);
 

--- a/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
@@ -16,12 +16,12 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         public ClientModuleBase(IInfluxDbRequestClient requestClient)
         {
-            this.RequestClient = requestClient;
+            RequestClient = requestClient;
         }
 
         protected virtual async Task<IInfluxDataApiResponse> GetAndValidateQueryAsync(string query)
         {
-            var response = await this.RequestClient.QueryAsync(query);
+            var response = await RequestClient.QueryAsync(query).ConfigureAwait(false);
             response.ValidateQueryResponse();
 
             return response;
@@ -29,7 +29,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         protected virtual async Task<IInfluxDataApiResponse> GetAndValidateQueryAsync(string dbName, string query)
         {
-            var response = await this.RequestClient.QueryAsync(dbName, query);
+            var response = await RequestClient.QueryAsync(dbName, query).ConfigureAwait(false);
             response.ValidateQueryResponse();
 
             return response;
@@ -37,7 +37,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         protected virtual async Task<IEnumerable<Serie>> ResolveSingleGetSeriesResultAsync(string query)
         {
-            var response = await this.RequestClient.QueryAsync(query);
+            var response = await RequestClient.QueryAsync(query).ConfigureAwait(false);
             var series = ResolveSingleGetSeriesResult(response);
 
             return series;
@@ -45,7 +45,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         protected virtual async Task<IEnumerable<Serie>> ResolveSingleGetSeriesResultAsync(string dbName, string query)
         {
-            var response = await this.RequestClient.QueryAsync(dbName, query);
+            var response = await RequestClient.QueryAsync(dbName, query).ConfigureAwait(false);
             var series = ResolveSingleGetSeriesResult(response);
 
             return series;

--- a/InfluxData.Net.InfluxDb/ClientModules/CqClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/CqClientModule.cs
@@ -24,7 +24,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> CreateContinuousQueryAsync(CqParams cqParams)
         {
             var query = _cqQueryBuilder.CreateContinuousQuery(cqParams);
-            var response = await base.GetAndValidateQueryAsync(cqParams.DbName, query);
+            var response = await base.GetAndValidateQueryAsync(cqParams.DbName, query).ConfigureAwait(false);
 
             return response;
         }
@@ -32,7 +32,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<ContinuousQuery>> GetContinuousQueriesAsync(string dbName)
         {
             var query = _cqQueryBuilder.GetContinuousQueries();
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
             var cqs = _cqResponseParser.GetContinuousQueries(dbName, series);
 
             return cqs;
@@ -41,7 +41,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DeleteContinuousQueryAsync(string dbName, string cqName)
         {
             var query = _cqQueryBuilder.DeleteContinuousQuery(dbName, cqName);
-            var response = await base.GetAndValidateQueryAsync(dbName, query);
+            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
 
             return response;
         }
@@ -49,7 +49,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> BackfillAsync(string dbName, BackfillParams backfillParams)
         {
             var query = _cqQueryBuilder.Backfill(dbName, backfillParams);
-            var response = await base.GetAndValidateQueryAsync(dbName, query);
+            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/DatabaseClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/DatabaseClientModule.cs
@@ -23,7 +23,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> CreateDatabaseAsync(string dbName)
         {
             var query = _databaseQueryBuilder.CreateDatabase(dbName);
-            var response = await base.GetAndValidateQueryAsync(query);
+            var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
 
             return response;
         }
@@ -31,7 +31,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<Database>> GetDatabasesAsync()
         {
             var query = _databaseQueryBuilder.GetDatabases();
-            var series = await base.ResolveSingleGetSeriesResultAsync(query);
+            var series = await base.ResolveSingleGetSeriesResultAsync(query).ConfigureAwait(false);
             var databases = _databaseResponseParser.GetDatabases(series);
 
             return databases;
@@ -40,7 +40,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DropDatabaseAsync(string dbName)
         {
             var query = _databaseQueryBuilder.DropDatabase(dbName);
-            var response = await base.GetAndValidateQueryAsync(query);
+            var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/DiagnosticsClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/DiagnosticsClientModule.cs
@@ -24,7 +24,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<Pong> PingAsync()
         {
             var watch = Stopwatch.StartNew();
-            var response = await this.RequestClient.RequestAsync(HttpMethod.Get, RequestPaths.Ping, includeAuthToQuery: false, headerIsBody: true);
+            var response = await RequestClient.RequestAsync(HttpMethod.Get, RequestPaths.Ping, includeAuthToQuery: false, headerIsBody: true).ConfigureAwait(false);
 
             watch.Stop();
 
@@ -41,7 +41,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<Stats> GetStatsAsync()
         {
             var query = _diagnosticsQueryBuilder.GetStats();
-            var series = await this.ResolveSingleGetSeriesResultAsync(query);
+            var series = await ResolveSingleGetSeriesResultAsync(query);
             var stats = _diagnosticsResponseParser.GetStats(series);
 
             return stats;
@@ -50,7 +50,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<Diagnostics> GetDiagnosticsAsync()
         {
             var query = _diagnosticsQueryBuilder.GetDiagnostics();
-            var series = await this.ResolveSingleGetSeriesResultAsync(query);
+            var series = await ResolveSingleGetSeriesResultAsync(query);
             var diagnostics = _diagnosticsResponseParser.GetDiagnostics(series);
 
             return diagnostics;

--- a/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
@@ -21,7 +21,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> AlterRetentionPolicyAsync(string dbName, string policyName, string duration, int replicationCopies)
         {
             var query = _retentionQueryBuilder.AlterRetentionPolicy(dbName, policyName, duration, replicationCopies);
-            var response = await base.GetAndValidateQueryAsync(query);
+            var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
@@ -23,7 +23,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<SerieSet>> GetSeriesAsync(string dbName, string measurementName = null, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.GetSeries(dbName, measurementName, filters);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
             var serieSets = _serieResponseParser.GetSerieSets(series);
 
             return serieSets;
@@ -31,13 +31,13 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
         public virtual async Task<IInfluxDataApiResponse> DropSeriesAsync(string dbName, string measurementName, IEnumerable<string> filters = null)
         {
-            return await DropSeriesAsync(dbName, new List<string>() { measurementName }, filters);
+            return await DropSeriesAsync(dbName, new List<string>() { measurementName }, filters).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> DropSeriesAsync(string dbName, IEnumerable<string> measurementNames, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.DropSeries(dbName, measurementNames, filters);
-            var response = await base.GetAndValidateQueryAsync(dbName, query);
+            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
 
             return response;
         }
@@ -45,7 +45,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<Measurement>> GetMeasurementsAsync(string dbName, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.GetMeasurements(dbName, filters);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
             var measurements = _serieResponseParser.GetMeasurements(series);
 
             return measurements;
@@ -54,7 +54,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DropMeasurementAsync(string dbName, string measurementName)
         {
             var query = _serieQueryBuilder.DropMeasurement(dbName, measurementName);
-            var response = await base.GetAndValidateQueryAsync(dbName, query);
+            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -20,21 +20,21 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         public virtual async Task<IInfluxDataApiResponse> QueryAsync(string query)
         {
             var requestParams = RequestParamsBuilder.BuildQueryRequestParams(query);
-            return await base.RequestAsync(HttpMethod.Get, RequestPaths.Query, requestParams);
+            return await RequestAsync(HttpMethod.Get, RequestPaths.Query, requestParams).ConfigureAwait(false);
 
         }
 
         public virtual async Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query)
         {
             var requestParams = RequestParamsBuilder.BuildQueryRequestParams(dbName, query);
-            return await base.RequestAsync(HttpMethod.Get, RequestPaths.Query, requestParams);
+            return await RequestAsync(HttpMethod.Get, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> PostAsync(WriteRequest writeRequest)
         {
             var httpContent = new StringContent(writeRequest.GetLines(), Encoding.UTF8, "text/plain");
             var requestParams = RequestParamsBuilder.BuildRequestParams(writeRequest.DbName, QueryParams.Precision, writeRequest.Precision);
-            var result = await base.RequestAsync(HttpMethod.Post, RequestPaths.Write, requestParams, httpContent);
+            var result = await RequestAsync(HttpMethod.Post, RequestPaths.Write, requestParams, httpContent).ConfigureAwait(false);
 
             return new InfluxDataApiWriteResponse(result.StatusCode, result.Body);
         }


### PR DESCRIPTION
I experienced requests that never returned a result. It seems that this is due to async and the await result not being returned to the originating thread. After adding ConfigureAwait to the awaitable calls within the library I was able to use the library successfully. I must note that the issue only occurred with requests that had more than a few kb's of data.

The following commit fixes the issue for me and does not seem to have any adverse side effects. For more info on ConfigureAwait, please review the following documentation:

https://msdn.microsoft.com/en-us/magazine/jj991977.aspx
https://msdn.microsoft.com/en-us/library/system.threading.tasks.task.configureawait(v=vs.110).aspx