### PR TITLE
Improved support for retention policies

### DIFF
--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -22,20 +22,20 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             _basicResponseParser = basicResponseParser;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retentionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
         {
-            var response = await WriteAsync(dbName, new [] { point }, retenionPolicy, precision).ConfigureAwait(false);
+            var response = await WriteAsync(dbName, new [] { point }, retentionPolicy, precision).ConfigureAwait(false);
 
             return response;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retentionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
         {
             var request = new WriteRequest(base.RequestClient.GetPointFormatter())
             {
                 DbName = dbName,
                 Points = points,
-                RetentionPolicy = retenionPolicy,
+                RetentionPolicy = retentionPolicy,
                 Precision = precision.GetParamValue()
             };
 

--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -22,14 +22,14 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             _basicResponseParser = basicResponseParser;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
         {
             var response = await WriteAsync(dbName, new [] { point }, retenionPolicy, precision).ConfigureAwait(false);
 
             return response;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds)
         {
             var request = new WriteRequest(base.RequestClient.GetPointFormatter())
             {

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -18,7 +18,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="retenionPolicy">The retenion policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
 
         /// <summary>
         /// Writes multiple serie points to the database.
@@ -28,7 +28,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="retenionPolicy">The retenion policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = "default", TimeUnit precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
 
         /// <summary>
         /// Executes a query against the database.

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -15,20 +15,20 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// </summary>
         /// <param name="dbName">Database name.</param>
         /// <param name="point">A serie <see cref="{Point}" />.</param>
-        /// <param name="retenionPolicy">The retenion policy.</param>
+        /// <param name="retentionPolicy">The retention policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(string dbName, Point point, string retentionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
 
         /// <summary>
         /// Writes multiple serie points to the database.
         /// </summary>
         /// <param name="dbName">Database name.</param>
         /// <param name="points">A serie <see cref="Array" />.</param>
-        /// <param name="retenionPolicy">The retenion policy.</param>
+        /// <param name="retentionPolicy">The retention policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retenionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(string dbName, IEnumerable<Point> points, string retentionPolicy = null, TimeUnit precision = TimeUnit.Milliseconds);
 
         /// <summary>
         /// Executes a query against the database.

--- a/InfluxData.Net.InfluxDb/ClientModules/IRetentionClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IRetentionClientModule.cs
@@ -1,10 +1,29 @@
 ﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using InfluxData.Net.Common.Infrastructure;
+using InfluxData.Net.InfluxDb.Models.Responses;
 
 namespace InfluxData.Net.InfluxDb.ClientModules
 {
     public interface IRetentionClientModule
     {
+        /// <summary>
+        /// Create a retention policy.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="policyName">Retention policy name.</param>
+        /// <param name="duration">New data keep duration.</param>
+        /// <param name="replicationCopies">Number of independent copies of data in the cluster (number of data nodes).</param>
+        /// <returns></returns>
+        Task<IInfluxDataApiResponse> CreateRetentionPolicyAsync(string dbName, string policyName, string duration, int replicationCopies);
+
+        /// <summary>
+        /// Get the retention policies.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <returns></returns>
+        Task<IEnumerable<RetentionPolicy>> GetRetentionPolicies(string dbName);
+
         /// <summary>
         /// Alters a retention policy.
         /// </summary>
@@ -14,5 +33,13 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="replicationCopies">Number of independent copies of data in the cluster (number of data nodes).</param>
         /// <returns></returns>
         Task<IInfluxDataApiResponse> AlterRetentionPolicyAsync(string dbName, string policyName, string duration, int replicationCopies);
+
+        /// <summary>
+        /// Drop a retention policy.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="policyName">Retention policy name.</param>
+        /// <returns></returns>
+        Task<IInfluxDataApiResponse> DropRetentionPolicyAsync(string dbName, string policyName);
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using InfluxData.Net.Common.Infrastructure;
+using InfluxData.Net.InfluxDb.Models.Responses;
 using InfluxData.Net.InfluxDb.QueryBuilders;
 using InfluxData.Net.InfluxDb.RequestClients;
 using InfluxData.Net.InfluxDb.ResponseParsers;
@@ -18,9 +20,34 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             _retentionResponseParser = retentionResponseParser;
         }
 
+        public virtual async Task<IInfluxDataApiResponse> CreateRetentionPolicyAsync(string dbName, string policyName, string duration, int replicationCopies)
+        {
+            var query = _retentionQueryBuilder.CreateRetentionPolicy(dbName, policyName, duration, replicationCopies);
+            var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
+
+            return response;
+        }
+
+        public async Task<IEnumerable<RetentionPolicy>> GetRetentionPolicies(string dbName)
+        {
+            var query = _retentionQueryBuilder.GetRetentionPolicies(dbName);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var rps = _retentionResponseParser.GetRetentionPolicies(dbName, series);
+
+            return rps;
+        }
+
         public virtual async Task<IInfluxDataApiResponse> AlterRetentionPolicyAsync(string dbName, string policyName, string duration, int replicationCopies)
         {
             var query = _retentionQueryBuilder.AlterRetentionPolicy(dbName, policyName, duration, replicationCopies);
+            var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
+
+            return response;
+        }
+
+        public virtual async Task<IInfluxDataApiResponse> DropRetentionPolicyAsync(string dbName, string policyName)
+        {
+            var query = _retentionQueryBuilder.DropRetentionPolicy(dbName, policyName);
             var response = await base.GetAndValidateQueryAsync(query).ConfigureAwait(false);
 
             return response;

--- a/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
+++ b/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
@@ -7,5 +7,6 @@
         public const string Id = "id";
         public const string Name = "name";
         public const string Precision = "precision";
+        public const string RetentionPolicy = "rp";
     }
 }

--- a/InfluxData.Net.InfluxDb/Constants/QueryStatements.cs
+++ b/InfluxData.Net.InfluxDb/Constants/QueryStatements.cs
@@ -13,7 +13,10 @@
         public const string GetDatabases = "SHOW DATABASES";
         public const string DropDatabase = "DROP DATABASE \"{0}\"";
 
+        public const string CreateRetentionPolicy = "CREATE RETENTION POLICY {0} ON {1} DURATION {2} REPLICATION {3}";
+        public const string GetRetentionPolicies = "SHOW RETENTION POLICIES ON {0}";
         public const string AlterRetentionPolicy = "ALTER RETENTION POLICY {0} ON {1} DURATION {2} REPLICATION {3}";
+        public const string DropRetentionPolicy = "DROP RETENTION POLICY {0} ON {1}";
 
         public const string CreateContinuousQuery = "CREATE CONTINUOUS QUERY {0} ON {1} {2}BEGIN {3} END;";
         public const string CreateContinuousQuerySubQuery = "SELECT {0} INTO \"{1}\" FROM {2} GROUP BY time({3}) {4} {5}";

--- a/InfluxData.Net.InfluxDb/InfluxData.Net.InfluxDb.csproj
+++ b/InfluxData.Net.InfluxDb/InfluxData.Net.InfluxDb.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Models\Responses\ContinuousQuery.cs" />
     <Compile Include="Models\Responses\Measurement.cs" />
     <Compile Include="Models\Responses\Diagnostics.cs" />
+    <Compile Include="Models\Responses\RetentionPolicy.cs" />
     <Compile Include="Models\Responses\SerieSet.cs" />
     <Compile Include="Models\Responses\Stats.cs" />
     <Compile Include="QueryBuilders\CqQueryBuilder_v_0_9_6.cs" />

--- a/InfluxData.Net.InfluxDb/Infrastructure/RequestParamsBuilder.cs
+++ b/InfluxData.Net.InfluxDb/Infrastructure/RequestParamsBuilder.cs
@@ -21,11 +21,20 @@ namespace InfluxData.Net.InfluxDb.Infrastructure
 
         public static IDictionary<string, string> BuildRequestParams(string dbName, string paramKey, string paramValue)
         {
-            return new Dictionary<string, string>
+            return BuildRequestParams(dbName, paramKey, paramValue, null, null);
+        }
+
+        public static IDictionary<string, string> BuildRequestParams(string dbName, string paramKey1, string paramValue1, string paramKey2, string paramValue2)
+        {
+            var dict = new Dictionary<string, string>
             {
-                { QueryParams.Db, dbName },
-                { paramKey, HttpUtility.UrlEncode(paramValue) }
+                {QueryParams.Db, dbName}
             };
+            if (paramKey1 != null && paramValue1 != null)
+                dict.Add(paramKey1, paramValue1);
+            if (paramKey2 != null && paramValue2 != null)
+                dict.Add(paramKey2, paramValue2);
+            return dict;
         }
     }
 }

--- a/InfluxData.Net.InfluxDb/Models/Responses/RetentionPolicy.cs
+++ b/InfluxData.Net.InfluxDb/Models/Responses/RetentionPolicy.cs
@@ -1,0 +1,33 @@
+﻿namespace InfluxData.Net.InfluxDb.Models.Responses
+{
+    /// <summary>
+    /// Represents <see cref="{RetentionPolicy}"/>.
+    /// </summary>
+    public class RetentionPolicy
+    {
+        /// <summary>
+        /// RP name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// RP duration.
+        /// </summary>
+        public string Duration { get; set; }
+
+        /// <summary>
+        /// RP shard group duration.
+        /// </summary>
+        public string ShardGroupduration { get; set; }
+
+        /// <summary>
+        /// RP replication copies.
+        /// </summary>
+        public int ReplicationCopies { get; set; }
+
+        /// <summary>
+        /// RP replication copies.
+        /// </summary>
+        public bool Default { get; set; }
+    }
+}

--- a/InfluxData.Net.InfluxDb/QueryBuilders/IRetentionQueryBuilder.cs
+++ b/InfluxData.Net.InfluxDb/QueryBuilders/IRetentionQueryBuilder.cs
@@ -3,13 +3,38 @@
     public interface IRetentionQueryBuilder
     {
         /// <summary>
+        /// Builds "create retention policy" query.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="policyName">Retention policy name.</param>
+        /// <param name="duration">New data keep duration.</param>
+        /// <param name="replication">Number of independent copies of data in the cluster (number of data nodes).</param>
+        /// <returns></returns>
+        string CreateRetentionPolicy(string dbName, string policyName, string duration, int replication);
+
+        /// <summary>
+        /// Builds "get retention policies" query.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <returns></returns>
+        string GetRetentionPolicies(string dbName);
+
+        /// <summary>
         /// Builds "alter retention policy" query.
         /// </summary>
         /// <param name="dbName">Database name.</param>
         /// <param name="policyName">Retention policy name.</param>
         /// <param name="duration">New data keep duration.</param>
-        /// <param name="replicationCopies">Number of independent copies of data in the cluster (number of data nodes).</param>
+        /// <param name="replication">Number of independent copies of data in the cluster (number of data nodes).</param>
         /// <returns></returns>
         string AlterRetentionPolicy(string dbName, string policyName, string duration, int replication);
+
+        /// <summary>
+        /// Builds "drop retention policy" query.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="policyName">Retention policy name.</param>
+        /// <returns></returns>
+        string DropRetentionPolicy(string dbName, string policyName);
     }
 }

--- a/InfluxData.Net.InfluxDb/QueryBuilders/RetentionQueryBuilder.cs
+++ b/InfluxData.Net.InfluxDb/QueryBuilders/RetentionQueryBuilder.cs
@@ -5,9 +5,30 @@ namespace InfluxData.Net.InfluxDb.QueryBuilders
 {
     internal class RetentionQueryBuilder : IRetentionQueryBuilder
     {
+        public string CreateRetentionPolicy(string dbName, string policyName, string duration, int replication)
+        {
+            var query = String.Format(QueryStatements.CreateRetentionPolicy, policyName, dbName, duration, replication);
+
+            return query;
+        }
+
+        public virtual string GetRetentionPolicies(string dbName)
+        {
+            var query = String.Format(QueryStatements.GetRetentionPolicies, dbName);
+
+            return query;
+        }
+
         public virtual string AlterRetentionPolicy(string dbName, string policyName, string duration, int replication)
         {
             var query = String.Format(QueryStatements.AlterRetentionPolicy, policyName, dbName, duration, replication);
+
+            return query;
+        }
+
+        public string DropRetentionPolicy(string dbName, string policyName)
+        {
+            var query = String.Format(QueryStatements.DropRetentionPolicy, policyName, dbName);
 
             return query;
         }

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -32,7 +32,7 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         public virtual async Task<IInfluxDataApiResponse> PostAsync(WriteRequest writeRequest)
         {
             var httpContent = new StringContent(writeRequest.GetLines(), Encoding.UTF8, "text/plain");
-            var requestParams = RequestParamsBuilder.BuildRequestParams(writeRequest.DbName, QueryParams.Precision, writeRequest.Precision);
+            var requestParams = RequestParamsBuilder.BuildRequestParams(writeRequest.DbName, QueryParams.Precision, writeRequest.Precision, QueryParams.RetentionPolicy, writeRequest.RetentionPolicy);
             var result = await base.RequestAsync(HttpMethod.Post, RequestPaths.Write, requestParams, httpContent).ConfigureAwait(false);
 
             return new InfluxDataApiWriteResponse(result.StatusCode, result.Body);

--- a/InfluxData.Net.InfluxDb/ResponseParsers/IRetentionResponseParser.cs
+++ b/InfluxData.Net.InfluxDb/ResponseParsers/IRetentionResponseParser.cs
@@ -1,7 +1,10 @@
-﻿namespace InfluxData.Net.InfluxDb.ResponseParsers
-{
+﻿using System.Collections.Generic;
+using InfluxData.Net.InfluxDb.Models.Responses;
+
+namespace InfluxData.Net.InfluxDb.ResponseParsers
+﻿{
     public interface IRetentionResponseParser
     {
-        
+        IEnumerable<RetentionPolicy> GetRetentionPolicies(string dbName, IEnumerable<Serie> series);
     }
 }

--- a/InfluxData.Net.InfluxDb/ResponseParsers/RetentionResponseParser.cs
+++ b/InfluxData.Net.InfluxDb/ResponseParsers/RetentionResponseParser.cs
@@ -1,6 +1,40 @@
-﻿namespace InfluxData.Net.InfluxDb.ResponseParsers
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using InfluxData.Net.InfluxDb.Models.Responses;
+
+namespace InfluxData.Net.InfluxDb.ResponseParsers
 {
     internal class RetentionResponseParser : IRetentionResponseParser
     {
+        public IEnumerable<RetentionPolicy> GetRetentionPolicies(string dbName, IEnumerable<Serie> series)
+        {
+            var rps = new List<RetentionPolicy>();
+
+            if (series == null)
+                return rps;
+
+            var serie = series.FirstOrDefault();
+            if (serie == null || serie.Values == null)
+                return rps;
+
+            var columns = serie.Columns.ToArray();
+            var indexOfName = Array.IndexOf(columns, "name");
+            var indexOfDuration = Array.IndexOf(columns, "duration");
+            var indexOfShardGroupDuration = Array.IndexOf(columns, "shardGroupDuration");
+            var indexOfReplica = Array.IndexOf(columns, "replicaN");
+            var indexOfDefault = Array.IndexOf(columns, "default");
+
+            rps.AddRange(serie.Values.Select(p => new RetentionPolicy()
+            {
+                Name = (string)p[indexOfName],
+                Duration = (string)p[indexOfDuration],
+                ShardGroupduration = (string)p[indexOfShardGroupDuration],
+                ReplicationCopies = (int)(long)p[indexOfReplica],
+                Default = (bool)p[indexOfDefault]
+            }));
+
+            return rps;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ If needed, a custom HttpClient can be used for making requests. Simply pass it i
  - _[GetMeasurementsAsync()](#getmeasurementsasync)_
  - _[DropMeasurementAsync()](#dropmeasurementasync)_
 - [Retention](#retention-module)
+ - _[CreateRetentionPolicyAsync()](#createretentionpolicyasync)_
+ - _[GetRetentionPolicies()](#getretentionpoliciesasync)_
  - _[AlterRetentionPolicyAsync()](#alterretentionpolicyasync)_
+ - _[DropRetentionPolicyAsync()](#dropretentionpolicyasync)_
 - [Diagnostics](#diagnostics-module)
  - _[PingAsync()](#pingasync)_
  - _[GetStatsAsync()](#getstatsasync)_
@@ -299,12 +302,36 @@ var response = await influxDbClient.Serie.DropMeasurementAsync("yourDbName", "me
 
 This module currently supports only a single [retention-policy](https://docs.influxdata.com/influxdb/v0.9/query_language/database_management/#retention-policy-management) action.
 
+#### CreateRetentionPolicyAsync
+
+This example creates the _retentionPolicyName_ policy to _1h_ and 3 copies:
+
+```cs
+var response = await influxDbClient.Retention.CreateRetentionPolicyAsync("yourDbName", "retentionPolicyName", "1h", 3);
+```
+
+#### GetRetentionPoliciesAsync
+
+Gets a list of all retention policies in the speified database:
+
+```cs
+var response = await influxDbClient.Retention.GetRetentionPoliciesAsync("yourDbName");
+```
+
 #### AlterRetentionPolicyAsync
 
 This example alter the _retentionPolicyName_ policy to _1h_ and 3 copies:
 
 ```cs
 var response = await influxDbClient.Retention.AlterRetentionPolicyAsync("yourDbName", "retentionPolicyName", "1h", 3);
+```
+
+#### DropRetentionPolicyAsync
+
+This example drops the _retentionPolicyName_ policycopies:
+
+```cs
+var response = await influxDbClient.Retention.AlterRetentionPolicyAsync("yourDbName", "retentionPolicyName");
 ```
 
 ### Diagnostics Module


### PR DESCRIPTION
Added the following methods to enable manipulation of retention policies:

- `CreateRetentionPolicyAsync(string dbName, string policyName, string duration, int copies)`
- `GetRetentionPolicies(string dbName)`
- `DropRetentionPolicyAsync(string dbName, string policyName)`

The current method for writing points did accept a retention policy, but it wasn't send to the server. The retention policy is now send to the server (if set).