### PR TITLE
Allow library to send batches with a limited size

### DIFF
--- a/InfluxData.Net.InfluxDb/ClientModules/SubModules/BatchWriter.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SubModules/BatchWriter.cs
@@ -19,7 +19,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         private int _interval;
         private bool _continueOnError;
         private bool _isRunning;
-        private long _maximumPointsPerBatch = long.MaxValue;
+        private long _maximumPointsPerBatch;
 
         /// <summary>
         /// Concurrent readings queue.
@@ -58,7 +58,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
             return new BatchWriter(_basicClientModule, dbName, retenionPolicy, precision);
         }
 
-        public virtual void Start(int interval = 1000, bool continueOnError = false)
+        public virtual void Start(int interval = 1000, bool continueOnError = false, long maximumPointsPerBatch = long.MaxValue)
         {
             if (interval <= 0)
                 throw new ArgumentException("Interval must be a positive value (milliseconds)");
@@ -67,6 +67,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
 
             _interval = interval;
             _isRunning = true;
+            _maximumPointsPerBatch = maximumPointsPerBatch
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             this.EnqueueBatchWritingAsync();
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
@@ -21,7 +21,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         /// <param name="interval">Interval between writes (milliseconds).</param>
         /// <param param name="continueOnError">Should continue running on write error? (defaults to false)</param>
         /// </summary>
-        void Start(int interval = 1000, bool continueOnError = false);
+        void Start(int interval = 1000, bool continueOnError = false, long maximumPointsPerBatch = long.MaxValue);
 
         /// <summary>
         /// Adds a single point to the BatchWriter points collection (uses BlockingCollection 

--- a/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
@@ -45,6 +45,11 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         void Stop();
 
         /// <summary>
+        /// Sets the maximum size of a batch.
+        /// </summary>
+        void SetMaximumBatchSize(long numPoints);
+
+        /// <summary>
         /// On batch writing error event handler.
         /// </summary>
         event EventHandler<Exception> OnError;


### PR DESCRIPTION
Some reverse proxies have a maximum client request size. To prevent 413 (request entity too large) responses I've added a method to set the size. I wanted to add it to the constructor and the CreateBatchWriter but was hesitant to modify the interface without consulting you (@pootzko)