### PR TITLE
Adding basic chunk support

### DIFF
--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -67,5 +67,20 @@ namespace InfluxData.Net.InfluxDb.ClientModules
 
             return resultSeries;
         }
+
+        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query)
+        {
+            var series = await base.ResolveSingleGetSeriesResultChunkedAsync(dbName, query).ConfigureAwait(false);
+
+            return series;
+        }
+
+        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries)
+        {
+            var results = await base.ResolveGetSeriesResultChunkedAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
+            var series = _basicResponseParser.FlattenResultsSeries(results);
+
+            return series;
+        }
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -68,18 +68,16 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return resultSeries;
         }
 
-        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query)
+        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query, long chunkSize = 10000)
         {
-            var series = await base.ResolveSingleGetSeriesResultChunkedAsync(dbName, query).ConfigureAwait(false);
-
+            var series = await base.ResolveSingleGetSeriesResultChunkedAsync(dbName, query, chunkSize).ConfigureAwait(false);
             return series;
         }
 
-        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries)
+        public virtual async Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries, long chunkSize = 10000)
         {
-            var results = await base.ResolveGetSeriesResultChunkedAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
+            var results = await base.ResolveGetSeriesResultChunkedAsync(dbName, queries.ToSemicolonSpaceSeparatedString(), chunkSize).ConfigureAwait(false);
             var series = _basicResponseParser.FlattenResultsSeries(results);
-
             return series;
         }
     }

--- a/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
@@ -90,5 +90,51 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             var response = await this.RequestClient.GetQueryAsync(dbName, query).ConfigureAwait(false);
             return response.ReadAs<QueryResponse>().Validate(this.RequestClient.Configuration.ThrowOnWarning).Results;
         }
+        
+        protected virtual async Task<IEnumerable<Serie>> ResolveSingleGetSeriesResultChunkedAsync(string dbName, string query)
+        {
+            var response = await this.RequestClient.GetQueryChunkedAsync(dbName, query).ConfigureAwait(false);
+            var series = ResolveSingleGetSeriesResultChunked(response);
+
+            return series;
+        }
+
+        protected virtual IEnumerable<Serie> ResolveSingleGetSeriesResultChunked(IInfluxDataApiResponse response)
+        {
+            //Split chunks to make it valid json
+            var queryBodies = response.Body.Split('\n');
+            var series = new List<Serie>();
+            foreach (var queryBody in queryBodies)
+            {
+                if (!string.IsNullOrWhiteSpace(queryBody))
+                {
+                    var queryResponse = Newtonsoft.Json.JsonConvert.DeserializeObject<QueryResponse>(queryBody).Validate(this.RequestClient.Configuration.ThrowOnWarning);
+                    var result = queryResponse.Results.Single();
+                    Validate.IsNotNull(result, "result");
+                    if (result != null)
+                    {
+                        series.AddRange(result.Series.ToList());
+                    }
+                }
+            }
+            return series;
+        }
+
+
+        protected virtual async Task<IEnumerable<SeriesResult>> ResolveGetSeriesResultChunkedAsync(string dbName, string query)
+        {
+            var response = await this.RequestClient.GetQueryChunkedAsync(dbName, query).ConfigureAwait(false);
+            var queryBodies = response.Body.Split('\n');
+            var results = new List<SeriesResult>();
+            foreach (var queryBody in queryBodies)
+            {
+                if (!string.IsNullOrWhiteSpace(queryBody))
+                {
+                    var queryResponse = Newtonsoft.Json.JsonConvert.DeserializeObject<QueryResponse>(queryBody).Validate(this.RequestClient.Configuration.ThrowOnWarning);
+                    results.AddRange(queryResponse.Results);
+                }
+            }
+            return results;
+        }
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -40,6 +40,14 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         Task<IEnumerable<Serie>> QueryAsync(string dbName, string query);
 
         /// <summary>
+        /// Executes a query against the database.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="query">Query to execute.</param>
+        /// <returns></returns>
+        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query);
+
+        /// <summary>
         /// Executes multiple queries against the database in a single request and extracts and flattens
         /// the series from all results into a single <see cref="Serie"/> collection.
         /// </summary>
@@ -47,6 +55,15 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="queries">Queries to execute.</param>
         /// <returns></returns>
         Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries);
+
+        /// <summary>
+        /// Executes multiple queries against the database in a single request and extracts and flattens
+        /// the series from all results into a single <see cref="Serie"/> collection.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="queries">Queries to execute.</param>
+        /// <returns></returns>
+        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries);
 
         /// <summary>
         /// Executes multiple queries against the database in a single request.

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -40,14 +40,6 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         Task<IEnumerable<Serie>> QueryAsync(string dbName, string query);
 
         /// <summary>
-        /// Executes a query against the database.
-        /// </summary>
-        /// <param name="dbName">Database name.</param>
-        /// <param name="query">Query to execute.</param>
-        /// <returns></returns>
-        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query);
-
-        /// <summary>
         /// Executes multiple queries against the database in a single request and extracts and flattens
         /// the series from all results into a single <see cref="Serie"/> collection.
         /// </summary>
@@ -57,13 +49,23 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries);
 
         /// <summary>
-        /// Executes multiple queries against the database in a single request and extracts and flattens
+        /// Executes a query against the database using a chunked response.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="query">Query to execute.</param>
+        /// <param name="chunkSize">Maximum number of rows in each chunk (default to 10000)</param>
+        /// <returns></returns>
+        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, string query, long chunkSize = 10000);
+
+        /// <summary>
+        /// Executes multiple queries against the database in a single request using a chunked response and extracts and flattens
         /// the series from all results into a single <see cref="Serie"/> collection.
         /// </summary>
         /// <param name="dbName">Database name.</param>
         /// <param name="queries">Queries to execute.</param>
+        /// <param name="chunkSize">Maximum number of rows in each chunk (default to 10000)</param>
         /// <returns></returns>
-        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries);
+        Task<IEnumerable<Serie>> QueryChunkedAsync(string dbName, IEnumerable<string> queries, long chunkSize = 10000);
 
         /// <summary>
         /// Executes multiple queries against the database in a single request.

--- a/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
+++ b/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
@@ -8,5 +8,7 @@
         public const string Name = "name";
         public const string Precision = "precision";
         public const string RetentionPolicy = "rp";
+        public const string Chunked = "chunked";
+        public const string ChunkSize = "chunk_size";
     }
 }

--- a/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
@@ -21,6 +21,15 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         Task<IInfluxDataApiResponse> GetQueryAsync(string query);
 
         /// <summary>
+        /// Executes a GET query against the InfluxDb API in a single request. Multiple queries can be 
+        /// passed in in the form of semicolon-delimited string.
+        /// </summary>
+        /// <param name="query">Queries to execute. For language specification please see
+        /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
+        /// <returns></returns>
+        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query);
+
+        /// <summary>
         /// Executes a POST query against the InfluxDb API in a single request. Multiple queries can be 
         /// passed in in the form of semicolon-delimited string.
         /// </summary>
@@ -48,6 +57,16 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
         /// <returns></returns>
         Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query);
+
+        /// <summary>
+        /// Executes a GET query against the database in a single request. Multiple queries can be 
+        /// passed in in the form of semicolon-delimited string.
+        /// </summary>
+        /// <param name="dbName">Database name.</param>
+        /// <param name="query">Queries to execute. For language specification please see
+        /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
+        /// <returns></returns>
+        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query);
 
         /// <summary>
         /// Executes a POST query against the database in a single request. Multiple queries can be 

--- a/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
@@ -21,15 +21,6 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         Task<IInfluxDataApiResponse> GetQueryAsync(string query);
 
         /// <summary>
-        /// Executes a GET query against the InfluxDb API in a single request. Multiple queries can be 
-        /// passed in in the form of semicolon-delimited string.
-        /// </summary>
-        /// <param name="query">Queries to execute. For language specification please see
-        /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
-        /// <returns></returns>
-        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query);
-
-        /// <summary>
         /// Executes a POST query against the InfluxDb API in a single request. Multiple queries can be 
         /// passed in in the form of semicolon-delimited string.
         /// </summary>
@@ -59,14 +50,24 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query);
 
         /// <summary>
+        /// Executes a GET query against the InfluxDb API in a single request with chunked response. Multiple queries can be 
+        /// passed in in the form of semicolon-delimited string.
+        /// </summary>
+        /// <param name="query">Queries to execute. For language specification please see
+        /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
+        /// <param name="chunkSize">Maximum number of rows in each chunk</param>/// <returns></returns>
+        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query, long chunkSize);
+
+        /// <summary>
         /// Executes a GET query against the database in a single request. Multiple queries can be 
         /// passed in in the form of semicolon-delimited string.
         /// </summary>
         /// <param name="dbName">Database name.</param>
         /// <param name="query">Queries to execute. For language specification please see
         /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
+        /// <param name="chunkSize">Maximum number of rows in each chunk</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query);
+        Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query, long chunkSize);
 
         /// <summary>
         /// Executes a POST query against the database in a single request. Multiple queries can be 

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -10,6 +10,7 @@ using InfluxData.Net.InfluxDb.Models;
 using System;
 using System.Linq;
 using InfluxData.Net.Common.Enums;
+using System.Collections.Generic;
 
 namespace InfluxData.Net.InfluxDb.RequestClients
 {
@@ -25,6 +26,11 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             return await this.QueryAsync(query, HttpMethod.Get).ConfigureAwait(false);
         }
 
+        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query)
+        {
+            return await this.QueryChunkedAsync(query, HttpMethod.Get).ConfigureAwait(false);
+        }
+
         public virtual async Task<IInfluxDataApiResponse> PostQueryAsync(string query)
         {
             return await this.QueryAsync(query, HttpMethod.Post).ConfigureAwait(false);
@@ -35,10 +41,21 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             var requestParams = RequestParamsBuilder.BuildQueryRequestParams(query);
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
+        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string query, HttpMethod method)
+        {
+            var requestParams = (Dictionary<string, string>)RequestParamsBuilder.BuildQueryRequestParams(query);
+            requestParams.Add("chunked", "true");
+            return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
+        }
 
         public virtual async Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query)
         {
             return await this.QueryAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
+        }
+        
+        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query)
+        {
+            return await this.QueryChunkedAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> PostQueryAsync(string dbName, string query)
@@ -49,6 +66,13 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         public virtual async Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query, HttpMethod method)
         {
             var requestParams = RequestParamsBuilder.BuildQueryRequestParams(dbName, query);
+            return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
+        }
+
+        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string dbName, string query, HttpMethod method)
+        {
+            var requestParams = (Dictionary<string,string>)RequestParamsBuilder.BuildQueryRequestParams(dbName, query);
+            requestParams.Add("chunked", "true");
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -26,9 +26,9 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             return await this.QueryAsync(query, HttpMethod.Get).ConfigureAwait(false);
         }
 
-        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query)
+        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string query, long chunkSize)
         {
-            return await this.QueryChunkedAsync(query, HttpMethod.Get).ConfigureAwait(false);
+            return await this.QueryChunkedAsync(query, chunkSize, HttpMethod.Get).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> PostQueryAsync(string query)
@@ -41,10 +41,11 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             var requestParams = RequestParamsBuilder.BuildQueryRequestParams(query);
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
-        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string query, HttpMethod method)
+        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string query, long chunkSize, HttpMethod method)
         {
             var requestParams = (Dictionary<string, string>)RequestParamsBuilder.BuildQueryRequestParams(query);
-            requestParams.Add("chunked", "true");
+            requestParams.Add(QueryParams.Chunked, "true");
+            requestParams.Add(QueryParams.ChunkSize, chunkSize.ToString());
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 
@@ -53,9 +54,9 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             return await this.QueryAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
         }
         
-        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query)
+        public virtual async Task<IInfluxDataApiResponse> GetQueryChunkedAsync(string dbName, string query, long chunkSize)
         {
-            return await this.QueryChunkedAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
+            return await this.QueryChunkedAsync(dbName, query, chunkSize, HttpMethod.Get).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> PostQueryAsync(string dbName, string query)
@@ -69,10 +70,11 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 
-        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string dbName, string query, HttpMethod method)
+        public virtual async Task<IInfluxDataApiResponse> QueryChunkedAsync(string dbName, string query, long chunkSize, HttpMethod method)
         {
             var requestParams = (Dictionary<string,string>)RequestParamsBuilder.BuildQueryRequestParams(dbName, query);
-            requestParams.Add("chunked", "true");
+            requestParams.Add(QueryParams.Chunked, "true");
+            requestParams.Add(QueryParams.ChunkSize, chunkSize.ToString());
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 

--- a/InfluxData.Net.sln
+++ b/InfluxData.Net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{91B2CB56-7AB0-4AF1-A081-95525F8A754C}"
 	ProjectSection(SolutionItems) = preProject
@@ -23,6 +23,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		circle.yml = circle.yml
 		Coverage.runsettings = Coverage.runsettings
 		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfluxData.Net.Tests", "InfluxData.Net.Tests\InfluxData.Net.Tests.csproj", "{56B4EF11-8B2A-4862-8723-FC4368274768}"
+	ProjectSection(ProjectDependencies) = postProject
+		{75A5DA2B-3818-49DB-A318-00C3E51B7BCD} = {75A5DA2B-3818-49DB-A318-00C3E51B7BCD}
+		{1A7A40B7-0801-4E75-9EE8-891FBD646C1E} = {1A7A40B7-0801-4E75-9EE8-891FBD646C1E}
+		{0B098CD4-78FA-422E-B028-283EA7886504} = {0B098CD4-78FA-422E-B028-283EA7886504}
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfluxData.Net.InfluxDb", "InfluxData.Net.InfluxDb\InfluxData.Net.InfluxDb.csproj", "{0B098CD4-78FA-422E-B028-283EA7886504}"
@@ -47,6 +54,10 @@ Global
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56B4EF11-8B2A-4862-8723-FC4368274768}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56B4EF11-8B2A-4862-8723-FC4368274768}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56B4EF11-8B2A-4862-8723-FC4368274768}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56B4EF11-8B2A-4862-8723-FC4368274768}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/InfluxData.Net.sln
+++ b/InfluxData.Net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{91B2CB56-7AB0-4AF1-A081-95525F8A754C}"
 	ProjectSection(SolutionItems) = preProject
@@ -23,13 +23,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		circle.yml = circle.yml
 		Coverage.runsettings = Coverage.runsettings
 		README.md = README.md
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfluxData.Net.Tests", "InfluxData.Net.Tests\InfluxData.Net.Tests.csproj", "{56B4EF11-8B2A-4862-8723-FC4368274768}"
-	ProjectSection(ProjectDependencies) = postProject
-		{75A5DA2B-3818-49DB-A318-00C3E51B7BCD} = {75A5DA2B-3818-49DB-A318-00C3E51B7BCD}
-		{1A7A40B7-0801-4E75-9EE8-891FBD646C1E} = {1A7A40B7-0801-4E75-9EE8-891FBD646C1E}
-		{0B098CD4-78FA-422E-B028-283EA7886504} = {0B098CD4-78FA-422E-B028-283EA7886504}
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfluxData.Net.InfluxDb", "InfluxData.Net.InfluxDb\InfluxData.Net.InfluxDb.csproj", "{0B098CD4-78FA-422E-B028-283EA7886504}"
@@ -54,10 +47,6 @@ Global
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9092CDD0-1585-48DE-B619-98F6FF01F8CC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{56B4EF11-8B2A-4862-8723-FC4368274768}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{56B4EF11-8B2A-4862-8723-FC4368274768}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{56B4EF11-8B2A-4862-8723-FC4368274768}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{56B4EF11-8B2A-4862-8723-FC4368274768}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B098CD4-78FA-422E-B028-283EA7886504}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Adds support for obtaining chunked responses from InfluxDb.
After all chunks have been received they are processed and returned in one list.
Chunks are not stitched together, as a chunk can be split on both series or number of rows. The consumer has to handle that part.

It would be nice to process each chunk as soon as the http data has been received, but that requires (I think) a lot more work.