### PR TITLE
Add epoch format parameter to query methods

### DIFF
--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -45,24 +45,24 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return response;
         }
 
-        public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, string query)
+        public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, string query, string epochFormat = null)
         {
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, epochFormat).ConfigureAwait(false);
 
             return series;
         }
 
-        public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries)
+        public virtual async Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries, string epochFormat = null)
         {
-            var results = await base.ResolveGetSeriesResultAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
+            var results = await base.ResolveGetSeriesResultAsync(dbName, queries.ToSemicolonSpaceSeparatedString(), epochFormat).ConfigureAwait(false);
             var series = _basicResponseParser.FlattenResultsSeries(results);
 
             return series;
         }
 
-        public virtual async Task<IEnumerable<IEnumerable<Serie>>> MultiQueryAsync(string dbName, IEnumerable<string> queries)
+        public virtual async Task<IEnumerable<IEnumerable<Serie>>> MultiQueryAsync(string dbName, IEnumerable<string> queries, string epochFormat = null)
         {
-            var results = await base.ResolveGetSeriesResultAsync(dbName, queries.ToSemicolonSpaceSeparatedString()).ConfigureAwait(false);
+            var results = await base.ResolveGetSeriesResultAsync(dbName, queries.ToSemicolonSpaceSeparatedString(), epochFormat).ConfigureAwait(false);
             var resultSeries = _basicResponseParser.MapResultsSeries(results);
 
             return resultSeries;

--- a/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/ClientModuleBase.cs
@@ -40,19 +40,19 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return response;
         }
 
-        protected virtual async Task<IInfluxDataApiResponse> GetAndValidateQueryAsync(string dbName, string query)
+        protected virtual async Task<IInfluxDataApiResponse> GetAndValidateQueryAsync(string dbName, string query, string epochFormat)
         {
-            return await this.RequestAndValidateQueryAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
+            return await this.RequestAndValidateQueryAsync(dbName, query, epochFormat, HttpMethod.Get).ConfigureAwait(false);
         }
 
-        protected virtual async Task<IInfluxDataApiResponse> PostAndValidateQueryAsync(string dbName, string query)
+        protected virtual async Task<IInfluxDataApiResponse> PostAndValidateQueryAsync(string dbName, string query, string epochFormat)
         {
-            return await this.RequestAndValidateQueryAsync(dbName, query, HttpMethod.Post).ConfigureAwait(false);
+            return await this.RequestAndValidateQueryAsync(dbName, query, epochFormat, HttpMethod.Post).ConfigureAwait(false);
         }
 
-        protected virtual async Task<IInfluxDataApiResponse> RequestAndValidateQueryAsync(string dbName, string query, HttpMethod method)
+        protected virtual async Task<IInfluxDataApiResponse> RequestAndValidateQueryAsync(string dbName, string query, string epochFormat, HttpMethod method)
         {
-            var response = await this.RequestClient.QueryAsync(dbName, query, method).ConfigureAwait(false);
+            var response = await this.RequestClient.QueryAsync(dbName, query, epochFormat, method).ConfigureAwait(false);
             response.ValidateQueryResponse(this.RequestClient.Configuration.ThrowOnWarning);
 
             return response;
@@ -66,9 +66,9 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return series;
         }
 
-        protected virtual async Task<IEnumerable<Serie>> ResolveSingleGetSeriesResultAsync(string dbName, string query)
+        protected virtual async Task<IEnumerable<Serie>> ResolveSingleGetSeriesResultAsync(string dbName, string query, string epochFormat)
         {
-            var response = await this.RequestClient.GetQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await this.RequestClient.GetQueryAsync(dbName, query, epochFormat).ConfigureAwait(false);
             var series = ResolveSingleGetSeriesResult(response);
 
             return series;
@@ -85,9 +85,9 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return series;
         }
 
-        protected virtual async Task<IEnumerable<SeriesResult>> ResolveGetSeriesResultAsync(string dbName, string query)
+        protected virtual async Task<IEnumerable<SeriesResult>> ResolveGetSeriesResultAsync(string dbName, string query, string epochFormat)
         {
-            var response = await this.RequestClient.GetQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await this.RequestClient.GetQueryAsync(dbName, query, epochFormat).ConfigureAwait(false);
             return response.ReadAs<QueryResponse>().Validate(this.RequestClient.Configuration.ThrowOnWarning).Results;
         }
     }

--- a/InfluxData.Net.InfluxDb/ClientModules/CqClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/CqClientModule.cs
@@ -24,7 +24,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> CreateContinuousQueryAsync(CqParams cqParams)
         {
             var query = _cqQueryBuilder.CreateContinuousQuery(cqParams);
-            var response = await base.PostAndValidateQueryAsync(cqParams.DbName, query).ConfigureAwait(false);
+            var response = await base.PostAndValidateQueryAsync(cqParams.DbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -32,7 +32,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<ContinuousQuery>> GetContinuousQueriesAsync(string dbName)
         {
             var query = _cqQueryBuilder.GetContinuousQueries();
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var cqs = _cqResponseParser.GetContinuousQueries(dbName, series);
 
             return cqs;
@@ -41,7 +41,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DeleteContinuousQueryAsync(string dbName, string cqName)
         {
             var query = _cqQueryBuilder.DeleteContinuousQuery(dbName, cqName);
-            var response = await base.PostAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.PostAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -49,7 +49,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> BackfillAsync(string dbName, BackfillParams backfillParams)
         {
             var query = _cqQueryBuilder.Backfill(dbName, backfillParams);
-            var response = await base.PostAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.PostAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/CqClientModule_v_0_9_6.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/CqClientModule_v_0_9_6.cs
@@ -24,7 +24,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> CreateContinuousQueryAsync(CqParams cqParams)
         {
             var query = _cqQueryBuilder.CreateContinuousQuery(cqParams);
-            var response = await base.GetAndValidateQueryAsync(cqParams.DbName, query).ConfigureAwait(false);
+            var response = await base.GetAndValidateQueryAsync(cqParams.DbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -32,7 +32,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<ContinuousQuery>> GetContinuousQueriesAsync(string dbName)
         {
             var query = _cqQueryBuilder.GetContinuousQueries();
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var cqs = _cqResponseParser.GetContinuousQueries(dbName, series);
 
             return cqs;
@@ -41,7 +41,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DeleteContinuousQueryAsync(string dbName, string cqName)
         {
             var query = _cqQueryBuilder.DeleteContinuousQuery(dbName, cqName);
-            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.GetAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -49,7 +49,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> BackfillAsync(string dbName, BackfillParams backfillParams)
         {
             var query = _cqQueryBuilder.Backfill(dbName, backfillParams);
-            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.GetAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -37,7 +37,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="dbName">Database name.</param>
         /// <param name="query">Query to execute.</param>
         /// <returns></returns>
-        Task<IEnumerable<Serie>> QueryAsync(string dbName, string query);
+        Task<IEnumerable<Serie>> QueryAsync(string dbName, string query, string epochFormat = null);
 
         /// <summary>
         /// Executes multiple queries against the database in a single request and extracts and flattens
@@ -46,7 +46,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="dbName">Database name.</param>
         /// <param name="queries">Queries to execute.</param>
         /// <returns></returns>
-        Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries);
+        Task<IEnumerable<Serie>> QueryAsync(string dbName, IEnumerable<string> queries, string epochFormat = null);
 
         /// <summary>
         /// Executes multiple queries against the database in a single request.
@@ -54,6 +54,6 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="dbName">Database name.</param>
         /// <param name="queries">Queries to execute.</param>
         /// <returns></returns>
-        Task<IEnumerable<IEnumerable<Serie>>> MultiQueryAsync(string dbName, IEnumerable<string> queries);
+        Task<IEnumerable<IEnumerable<Serie>>> MultiQueryAsync(string dbName, IEnumerable<string> queries, string epochFormat = null);
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/RetentionClientModule.cs
@@ -31,7 +31,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public async Task<IEnumerable<RetentionPolicy>> GetRetentionPoliciesAsync(string dbName)
         {
             var query = _retentionQueryBuilder.GetRetentionPolicies(dbName);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var rps = _retentionResponseParser.GetRetentionPolicies(dbName, series);
 
             return rps;

--- a/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
@@ -28,7 +28,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<SerieSet>> GetSeriesAsync(string dbName, string measurementName = null, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.GetSeries(dbName, measurementName, filters);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var serieSets = _serieResponseParser.GetSerieSets(series);
 
             return serieSets;
@@ -42,7 +42,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DropSeriesAsync(string dbName, IEnumerable<string> measurementNames, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.DropSeries(dbName, measurementNames, filters);
-            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.GetAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -50,7 +50,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<Measurement>> GetMeasurementsAsync(string dbName, IEnumerable<string> filters = null)
         {
             var query = _serieQueryBuilder.GetMeasurements(dbName, filters);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var measurements = _serieResponseParser.GetMeasurements(series);
 
             return measurements;
@@ -59,7 +59,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IInfluxDataApiResponse> DropMeasurementAsync(string dbName, string measurementName)
         {
             var query = _serieQueryBuilder.DropMeasurement(dbName, measurementName);
-            var response = await base.GetAndValidateQueryAsync(dbName, query).ConfigureAwait(false);
+            var response = await base.GetAndValidateQueryAsync(dbName, query, null).ConfigureAwait(false);
 
             return response;
         }
@@ -67,7 +67,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<string>> GetTagKeysAsync(string dbName, string measurementName)
         {
             var query = _serieQueryBuilder.GetTagKeys(dbName, measurementName);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var tagKeys = _serieResponseParser.GetTagKeys(series);
 
             return tagKeys;
@@ -76,7 +76,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<TagValue>> GetTagValuesAsync(string dbName, string measurementName, string tagName)
         {
             var query = _serieQueryBuilder.GetTagValues(dbName, measurementName, tagName);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var tagValues = _serieResponseParser.GetTagValues(series);
 
             return tagValues;
@@ -85,7 +85,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         public virtual async Task<IEnumerable<FieldKey>> GetFieldKeysAsync(string dbName, string measurementName)
         {
             var query = _serieQueryBuilder.GetFieldKeys(dbName, measurementName);
-            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query).ConfigureAwait(false);
+            var series = await base.ResolveSingleGetSeriesResultAsync(dbName, query, null).ConfigureAwait(false);
             var fieldKeys = _serieResponseParser.GetFieldKeys(series);
 
             return fieldKeys;

--- a/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
+++ b/InfluxData.Net.InfluxDb/Constants/QueryParams.cs
@@ -8,5 +8,6 @@
         public const string Name = "name";
         public const string Precision = "precision";
         public const string RetentionPolicy = "rp";
+        public const string Epoch = "epoch";
     }
 }

--- a/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/IInfluxDbRequestClient.cs
@@ -47,7 +47,7 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         /// <param name="query">Queries to execute. For language specification please see
         /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query);
+        Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query, string epochFormat);
 
         /// <summary>
         /// Executes a POST query against the database in a single request. Multiple queries can be 
@@ -68,7 +68,7 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         /// <a href="https://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html">InfluxDb documentation</a>.</param>
         /// <param name="method">The HTTP method to use when executing the query.</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query, HttpMethod method);
+        Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query, string epochFormat, HttpMethod method);
 
         /// <summary>
         /// Writes series to the database based on <see cref="{WriteRequest}"/> object.

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -36,19 +36,19 @@ namespace InfluxData.Net.InfluxDb.RequestClients
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 
-        public virtual async Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query)
+        public virtual async Task<IInfluxDataApiResponse> GetQueryAsync(string dbName, string query, string epochFormat)
         {
-            return await this.QueryAsync(dbName, query, HttpMethod.Get).ConfigureAwait(false);
+            return await this.QueryAsync(dbName, query, epochFormat, HttpMethod.Get).ConfigureAwait(false);
         }
 
         public virtual async Task<IInfluxDataApiResponse> PostQueryAsync(string dbName, string query)
         {
-            return await this.QueryAsync(dbName, query, HttpMethod.Post).ConfigureAwait(false);
+            return await this.QueryAsync(dbName, query, null, HttpMethod.Post).ConfigureAwait(false);
         }
 
-        public virtual async Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query, HttpMethod method)
+        public virtual async Task<IInfluxDataApiResponse> QueryAsync(string dbName, string query, string epochFormat, HttpMethod method)
         {
-            var requestParams = RequestParamsBuilder.BuildQueryRequestParams(dbName, query);
+            var requestParams = RequestParamsBuilder.BuildRequestParams(dbName, QueryParams.Query, query, QueryParams.Epoch, epochFormat);
             return await base.RequestAsync(method, RequestPaths.Query, requestParams).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Add further parameters to the client classes to allow specifying an epoch timestamp format when querying. The default behavior remains the same, i.e. the InfluxDb default setting will be used.

This is the corresponding PR to Issue  #38.