### PR TITLE
Add support for parameterized queries

### DIFF
--- a/InfluxData.Net.Common/Helpers/StringExtensions.cs
+++ b/InfluxData.Net.Common/Helpers/StringExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace InfluxData.Net.Common
+{
+    public static class StringExtensions
+    {
+        // http://www.mvvm.ro/2011/03/sanitize-strings-against-sql-injection.html
+        public static string Sanitize(this string stringValue)
+        {
+            if (null == stringValue)
+                return stringValue;
+            return stringValue
+                        .RegexReplace("-{2,}", "-")
+                        .RegexReplace(@"[*/]+", string.Empty)
+                        .RegexReplace(@"(;|\s)(exec|execute|select|insert|update|delete|create|alter|drop|rename|truncate|backup|restore)\s", 
+                                      string.Empty, RegexOptions.IgnoreCase);
+        }
+
+
+        private static string RegexReplace(this string stringValue, string matchPattern, string toReplaceWith)
+        {
+            return Regex.Replace(stringValue, matchPattern, toReplaceWith);
+        }
+
+        private static string RegexReplace(this string stringValue, string matchPattern, string toReplaceWith, RegexOptions regexOptions)
+        {
+            return Regex.Replace(stringValue, matchPattern, toReplaceWith, regexOptions);
+        }
+
+    }
+}

--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -7,12 +7,21 @@ using InfluxData.Net.InfluxDb.Models.Responses;
 using InfluxData.Net.InfluxDb.RequestClients;
 using InfluxData.Net.InfluxDb.ResponseParsers;
 using InfluxData.Net.Common.Constants;
+using InfluxData.Net.InfluxDb.Helpers;
+using System;
 
 namespace InfluxData.Net.InfluxDb.ClientModules
 {
     public class BasicClientModule : ClientModuleBase, IBasicClientModule
     {
         private readonly IBasicResponseParser _basicResponseParser;
+
+        public Task<IEnumerable<Serie>> QueryAsync(string query, object param = null, string dbName = null, string epochFormat = null, long? chunkSize = default(long?))
+        {
+            var buildQuery = QueryHelpers.BuildParameterizedQuery(query, param);
+
+            return this.QueryAsync(buildQuery, dbName, epochFormat, chunkSize);
+        }
 
         public virtual async Task<IEnumerable<Serie>> QueryAsync(string query, string dbName = null, string epochFormat = null, long? chunkSize = null)
         {

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -10,6 +10,18 @@ namespace InfluxData.Net.InfluxDb.ClientModules
     public interface IBasicClientModule
     {
         /// <summary>
+        /// Executes a parameterized query against the database. If chunkSize is specified, responses 
+        /// will be broken down by number of returned rows. 
+        /// </summary>
+        /// <param name="query">Query to execute.</param>
+        /// <param name="param">The parameters to pass, if any. (OPTIONAL)</param>
+        /// <param name="dbName">Database name. (OPTIONAL)</param>
+        /// <param name="epochFormat">Epoch timestamp format. (OPTIONAL)</param>
+        /// <param name="chunkSize">Maximum number of rows per chunk. (OPTIONAL)</param>
+        /// <returns></returns>
+        Task<IEnumerable<Serie>> QueryAsync(string query, object param = null, string dbName = null, string epochFormat = null, long? chunkSize = null);
+
+        /// <summary>
         /// Executes a query against the database. If chunkSize is specified, responses 
         /// will be broken down by number of returned rows. 
         /// </summary>

--- a/InfluxData.Net.InfluxDb/Helpers/QueryHelpers.cs
+++ b/InfluxData.Net.InfluxDb/Helpers/QueryHelpers.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using InfluxData.Net.Common;
+using System.Linq;
+
+namespace InfluxData.Net.InfluxDb.Helpers
+{
+    public static class QueryHelpers
+    {
+        public static string BuildParameterizedQuery(string query, object param)
+        {
+            var paramRegex = "@([A-Za-z0-9åäöÅÄÖ'_-]+)";
+
+            var matches = Regex.Matches(query, paramRegex);
+
+            Type t = param.GetType();
+            PropertyInfo[] pi = t.GetProperties();
+
+            foreach(Match match in matches) 
+            {
+                if (!pi.Any(x => match.Groups[0].Value.Contains(x.Name)))
+                    throw new ArgumentException($"Missing parameter value for {match.Groups[0].Value}");
+            }
+
+            foreach (var propertyInfo in pi)
+            {
+                var paramValue = propertyInfo.GetValue(param);
+                var paramType = paramValue.GetType();
+
+                if(!paramType.IsPrimitive && paramType != typeof(String))
+                    throw new NotSupportedException($"The type {paramType.Name} is not a supported query parameter type.");
+
+                var sanitizedParamValue = paramValue;
+
+                if(paramType == typeof(String)) {
+                    sanitizedParamValue = ((string)sanitizedParamValue).Sanitize();
+                }
+
+                while (Regex.IsMatch(query, $"@{propertyInfo.Name}"))
+                {
+                    var match = Regex.Match(query, $"@{propertyInfo.Name}");
+
+                    query = query.Remove(match.Index, match.Length);
+                    query = query.Insert(match.Index, $"{sanitizedParamValue}");
+                }
+            }
+
+            return query;
+        }
+    }
+}

--- a/InfluxData.Net.InfluxDb/Helpers/QueryHelpers.cs
+++ b/InfluxData.Net.InfluxDb/Helpers/QueryHelpers.cs
@@ -10,36 +10,36 @@ namespace InfluxData.Net.InfluxDb.Helpers
     {
         public static string BuildParameterizedQuery(string query, object param)
         {
-            var paramRegex = "@([A-Za-z0-9åäöÅÄÖ'_-]+)";
-
-            var matches = Regex.Matches(query, paramRegex);
-
             Type t = param.GetType();
             PropertyInfo[] pi = t.GetProperties();
 
-            foreach(Match match in matches) 
-            {
-                if (!pi.Any(x => match.Groups[0].Value.Contains(x.Name)))
-                    throw new ArgumentException($"Missing parameter value for {match.Groups[0].Value}");
-            }
 
             foreach (var propertyInfo in pi)
             {
+                var regex = $@"@{propertyInfo.Name}(?!\w)";
+
+                if(!Regex.IsMatch(query, regex) && Nullable.GetUnderlyingType(propertyInfo.GetType()) != null)
+                    throw new ArgumentException($"Missing parameter identifier for @{propertyInfo.Name}");
+
                 var paramValue = propertyInfo.GetValue(param);
+                if (paramValue == null)
+                    continue;
+
                 var paramType = paramValue.GetType();
 
-                if(!paramType.IsPrimitive && paramType != typeof(String))
+                if (!paramType.IsPrimitive && paramType != typeof(String) && paramType != typeof(DateTime))
                     throw new NotSupportedException($"The type {paramType.Name} is not a supported query parameter type.");
 
                 var sanitizedParamValue = paramValue;
 
-                if(paramType == typeof(String)) {
+                if (paramType == typeof(String))
+                {
                     sanitizedParamValue = ((string)sanitizedParamValue).Sanitize();
                 }
 
-                while (Regex.IsMatch(query, $"@{propertyInfo.Name}"))
+                while (Regex.IsMatch(query, regex))
                 {
-                    var match = Regex.Match(query, $"@{propertyInfo.Name}");
+                    var match = Regex.Match(query, regex);
 
                     query = query.Remove(match.Index, match.Length);
                     query = query.Insert(match.Index, $"{sanitizedParamValue}");

--- a/InfluxData.Net.Tests/InfluxData.Net.Tests.csproj
+++ b/InfluxData.Net.Tests/InfluxData.Net.Tests.csproj
@@ -32,4 +32,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="InfluxDb\Helpers\" />
+  </ItemGroup>
 </Project>

--- a/InfluxData.Net.Tests/InfluxDb/Helpers/QueryHelpersTests.cs
+++ b/InfluxData.Net.Tests/InfluxDb/Helpers/QueryHelpersTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using InfluxData.Net.InfluxDb.Helpers;
+using Xunit;
+
+namespace InfluxData.Net.Tests
+{
+    [Trait("InfluxDb SerieExtensions", "Serie extensions")]
+    public class QueryHelpersTests
+    {
+        [Fact]
+        public void Building_Parameterized_Query_Returns_Correct_String()
+        {
+            var firstTag = "firstTag";
+            var firstTagValue = "firstTagValue";
+
+            var firstField = "firstField";
+            var firstFieldValue = "firstFieldValue";
+
+            var query = "SELECT * FROM fakeMeasurement " +
+                       $"WHERE {firstTag} = @FirstTagValue " +
+                       $"AND {firstField} = @FirstFieldValue";
+
+            var expectedNewQuery = "SELECT * FROM fakeMeasurement " +
+                                   $"WHERE {firstTag} = {firstTagValue} " +
+                                   $"AND {firstField} = {firstFieldValue}";
+
+            var actualNewQuery = QueryHelpers.BuildParameterizedQuery(
+            query,
+                new
+                {
+                    @FirstTagValue = firstTagValue,
+                    @FirstFieldValue = firstFieldValue
+                });
+
+            Assert.Equal(expectedNewQuery, actualNewQuery);
+        }
+
+
+        [Fact]
+        public void Using_Non_Primitive_And_Non_String_Type_In_Parameters_Throws_NotSupportedException()
+        {
+            var firstTag = "firstTag";
+            var firstTagValue = "firstTagValue";
+
+            var firstField = "firstField";
+
+            var query = "SELECT * FROM fakeMeasurement " +
+                       $"WHERE {firstTag} = @FirstTagValue " +
+                       $"AND {firstField} = @FirstFieldValue";
+
+            Func<string> func = new Func<string>(() =>
+            {
+                return QueryHelpers.BuildParameterizedQuery(
+                query,
+                new
+                {
+                    @FirstTagValue = firstTagValue,
+                    @FirstFieldValue = new List<string>() { "NOT ACCEPTED" }
+                });
+            });
+
+            Assert.Throws(typeof(NotSupportedException), func);
+        }
+
+        [Fact]
+        public void Building_Parameterized_Query_With_Missing_Parameters_Throws_ArgumentException()
+        {
+            var firstTag = "firstTag";
+            var firstTagValue = "firstTagValue";
+
+            var firstField = "firstField";
+
+            var query = "SELECT * FROM fakeMeasurement " +
+                       $"WHERE {firstTag} = @FirstTagValue " +
+                       $"AND {firstField} = @FirstFieldValue";
+
+            Func<string> func = new Func<string>(() =>
+            {
+                return QueryHelpers.BuildParameterizedQuery(
+                query,
+                new
+                {
+                    @FirstTagValue = firstTagValue
+                });
+            });
+
+            Assert.Throws(typeof(ArgumentException), func);
+        }
+    }
+}


### PR DESCRIPTION
With support for parameterized queries, InfluxDB can be queried in the following manner: 

```csharp
var serialNumber = "F2EA2B0CDFF"
var query = "SELECT * FROM cpuTemp WHERE \"serialNumber\" = @SerialNumber";
var response = await influxDbClient.Client.QueryAsync(
     query: query, 
     param: new 
     { 
           @SerialNumber = serialNumber 
     }, 
     dbName: "yourDbName");
```

The signature for the new overload is:
```csharp
public Task<IEnumerable<Serie>> QueryAsync(string query, object param = null, string dbName = null, string epochFormat = null, long? chunkSize = default(long?));
```

The supported types of parameters are [primitive types](https://msdn.microsoft.com/en-us/library/system.type.isprimitive(v=vs.110).aspx#Anchor_1) as well as Strings. Trying to use un-supported types will throw a NotSupportedException. 

All strings are sanitized.
