### PR TITLE
Small changes to allow Microsecond and Tick (100 ns) resolutions

### DIFF
--- a/InfluxData.Net.Common/Constants/TimeUnit.cs
+++ b/InfluxData.Net.Common/Constants/TimeUnit.cs
@@ -3,20 +3,61 @@ namespace InfluxData.Net.Common.Constants
     /// <summary>
     /// Time unit used in writing data points or parsing series.
     /// </summary>
-    public static class TimeUnit
+    /// 
+
+    public enum TimeUnit
     {
-        // NOTE: currently not supported
-        //public const string Nanoseconds = "n";
-
-        // NOTE: currently not supported
-        //public const string Microseconds = "u";
-
-        public const string Milliseconds = "ms";
-
-        public const string Seconds = "s";
-
-        public const string Minutes = "m";
-
-        public const string Hours = "h";
+        Nanoseconds = 0,
+        Ticks = 1,
+        Microseconds = 2,
+        Milliseconds = 3,
+        Seconds = 4,
+        Minutes = 5,
+        Hours = 6
     }
+
+    public static class TimeUnitExtensions
+    {
+        public static string ToEpochFormat(this TimeUnit tu)
+        {
+            switch (tu)
+            {
+                case TimeUnit.Nanoseconds:
+                    return "ns";
+                case TimeUnit.Ticks:
+                    return "ns";
+                case TimeUnit.Microseconds:
+                    return "u";
+                case TimeUnit.Milliseconds:
+                    return "ms";
+                case TimeUnit.Seconds:
+                    return "s";
+                case TimeUnit.Minutes:
+                    return "h";
+                case TimeUnit.Hours:
+                    return "h";
+                default:
+                    return "ns";
+            }
+        }
+    }
+
+    //public static class TimeUnit
+    //{
+    //    // NOTE: currently not supported
+    //    //public const string Nanoseconds = "n";
+
+    //    // NOTE: currently not supported
+    //    //public const string Microseconds = "u";
+
+    //    public const string Ticks = "ticks";
+
+    //    public const string Milliseconds = "ms";
+
+    //    public const string Seconds = "s";
+
+    //    public const string Minutes = "m";
+
+    //    public const string Hours = "h";
+    //}
 }

--- a/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
+++ b/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
@@ -28,13 +28,22 @@ namespace InfluxData.Net.Common.Helpers
         /// <param name="date">DateTime to convert.</param>
         /// <param name="precision">Precision (optional, defaults to milliseconds)</param>
         /// <returns>Unix-style timestamp in milliseconds.</returns>
-        public static long ToUnixTime(this DateTime date, string precision = TimeUnit.Milliseconds)
+        public static long ToUnixTime(this DateTime date, TimeUnit precision = TimeUnit.Ticks)
         {
             var span = date - _epoch;
             double fractionalSpan;
 
             switch (precision)
             {
+                case TimeUnit.Nanoseconds:
+                    fractionalSpan = span.Ticks * 100;
+                    break;
+                case TimeUnit.Ticks:
+                    fractionalSpan = span.Ticks * 100;
+                    break;
+                case TimeUnit.Microseconds:
+                    fractionalSpan = span.Ticks / 10;
+                    break;
                 case TimeUnit.Milliseconds:
                     fractionalSpan = span.TotalMilliseconds;
                     break;
@@ -61,10 +70,12 @@ namespace InfluxData.Net.Common.Helpers
         /// <param name="unixTime">The unix time (expects milliseconds by default).</param>
         /// <param name="precision">Precision (optional, defaults to milliseconds)</param>
         /// <returns>DateTime object.</returns>
-        public static DateTime FromUnixTime(this long unixTime, string precision = TimeUnit.Milliseconds)
+        public static DateTime FromUnixTime(this long unixTime, TimeUnit precision = TimeUnit.Ticks)
         {
             switch (precision)
             {
+                case TimeUnit.Ticks:
+                    return _epoch.AddTicks(unixTime);
                 case TimeUnit.Milliseconds:
                     return _epoch.AddMilliseconds(unixTime);
                 case TimeUnit.Seconds:

--- a/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/BasicClientModule.cs
@@ -51,14 +51,14 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             _basicResponseParser = basicResponseParser;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(Point point, string dbName = null, string retentionPolicy = null, string precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(Point point, string dbName = null, string retentionPolicy = null, TimeUnit precision = TimeUnit.Ticks)
         {
             var response = await WriteAsync(new [] { point }, dbName, retentionPolicy, precision).ConfigureAwait(false);
 
             return response;
         }
 
-        public virtual async Task<IInfluxDataApiResponse> WriteAsync(IEnumerable<Point> points, string dbName = null, string retentionPolicy = null, string precision = TimeUnit.Milliseconds)
+        public virtual async Task<IInfluxDataApiResponse> WriteAsync(IEnumerable<Point> points, string dbName = null, string retentionPolicy = null, TimeUnit precision = TimeUnit.Ticks)
         {
             var request = new WriteRequest(base.RequestClient.GetPointFormatter())
             {

--- a/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/IBasicClientModule.cs
@@ -63,7 +63,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="retentionPolicy">The retention policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(Point point, string dbName = null, string retentionPolicy = null, string precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(Point point, string dbName = null, string retentionPolicy = null, TimeUnit precision = TimeUnit.Ticks);
 
         /// <summary>
         /// Writes multiple serie points to the database.
@@ -73,6 +73,6 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="retentionPolicy">The retention policy.</param>
         /// <param name="precision">InfluxDb time precision to use (defaults to 'ms')</param>
         /// <returns></returns>
-        Task<IInfluxDataApiResponse> WriteAsync(IEnumerable<Point> points, string dbName = null, string retentionPolicy = null, string precision = TimeUnit.Milliseconds);
+        Task<IInfluxDataApiResponse> WriteAsync(IEnumerable<Point> points, string dbName = null, string retentionPolicy = null, TimeUnit precision = TimeUnit.Ticks);
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/ISerieClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/ISerieClientModule.cs
@@ -90,6 +90,6 @@ namespace InfluxData.Net.InfluxDb.ClientModules
         /// <param name="retenionPolicy">Retention policy.</param>
         /// <param name="precision">Precision.</param>
         /// <returns>BatchWriter instance.</returns>
-        IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, string precision = TimeUnit.Milliseconds);
+        IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, TimeUnit precision = TimeUnit.Ticks);
     }
 }

--- a/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SerieClientModule.cs
@@ -90,7 +90,7 @@ namespace InfluxData.Net.InfluxDb.ClientModules
             return fieldKeys;
         }
 
-        public IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, string precision = TimeUnit.Milliseconds)
+        public IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, TimeUnit precision = TimeUnit.Ticks)
         {
             return ((IBatchWriterFactory)_batchWriter).CreateBatchWriter(dbName, retenionPolicy, precision);
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/SubModules/BatchWriter.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SubModules/BatchWriter.cs
@@ -13,7 +13,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         private readonly IBasicClientModule _basicClientModule;
         private string _dbName;
         private string _retentionPolicy;
-        private string _precision;
+        private TimeUnit _precision;
         private int _interval;
         private bool _continueOnError;
         private bool _isRunning;
@@ -42,7 +42,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         /// Constructor used by BatchWriter to create new instances of BatchWriter (through the CreateBatchWriter() method) with
         /// IBasicClientModule from InfluxDbClient. This instance BatchWriter instance is served to the end users.
         /// </summary>
-        private BatchWriter(IBasicClientModule basicClientModule, string dbName, string retenionPolicy = null, string precision = TimeUnit.Milliseconds)
+        private BatchWriter(IBasicClientModule basicClientModule, string dbName, string retenionPolicy = null, TimeUnit precision = TimeUnit.Ticks)
         {
             _basicClientModule = basicClientModule;
             _dbName = dbName;
@@ -51,7 +51,7 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
             _pointCollection = new BlockingCollection<Point>();
         }
 
-        public virtual IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, string precision = TimeUnit.Milliseconds)
+        public virtual IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, TimeUnit precision = TimeUnit.Ticks)
         {
             return new BatchWriter(_basicClientModule, dbName, retenionPolicy, precision);
         }

--- a/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
+++ b/InfluxData.Net.InfluxDb/ClientModules/SubModules/IBatchWriter.cs
@@ -71,6 +71,6 @@ namespace InfluxData.Net.InfluxDb.ClientSubModules
         /// <param name="retenionPolicy">Retention policy.</param>
         /// <param name="precision">Precision.</param>
         /// <returns>BatchWriter instance.</returns>
-        IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, string precision = TimeUnit.Milliseconds);
+        IBatchWriter CreateBatchWriter(string dbName, string retenionPolicy = null, TimeUnit precision = TimeUnit.Ticks);
     }
 }

--- a/InfluxData.Net.InfluxDb/Formatters/IPointFormatter.cs
+++ b/InfluxData.Net.InfluxDb/Formatters/IPointFormatter.cs
@@ -6,7 +6,7 @@ namespace InfluxData.Net.InfluxDb.Formatters
 {
     public interface IPointFormatter
     {
-        string PointToString(Point point, string precision = TimeUnit.Milliseconds);
+        string PointToString(Point point, TimeUnit precision = TimeUnit.Ticks);
 
         Serie PointToSerie(Point point);
     }

--- a/InfluxData.Net.InfluxDb/Formatters/PointFormatter.cs
+++ b/InfluxData.Net.InfluxDb/Formatters/PointFormatter.cs
@@ -15,7 +15,7 @@ namespace InfluxData.Net.InfluxDb.Formatters
         /// Returns a point represented in line protocol format for writing to the InfluxDb API endpoint
         /// </summary>
         /// <returns>A string that represents this instance.</returns>
-        public virtual string PointToString(Point point, string precision = TimeUnit.Milliseconds)
+        public virtual string PointToString(Point point, TimeUnit precision = TimeUnit.Ticks)
         {
             Validate.IsNotNullOrEmpty(point.Name, "measurement");
             Validate.IsNotNull(point.Tags, "tags");
@@ -139,7 +139,7 @@ namespace InfluxData.Net.InfluxDb.Formatters
             return $"{EscapeTagOrKeyValue(key)}={result}";
         }
 
-        protected virtual string FormatPointTimestamp(Point point, string precision = TimeUnit.Milliseconds)
+        protected virtual string FormatPointTimestamp(Point point, TimeUnit precision = TimeUnit.Ticks)
         {
             return point.Timestamp.HasValue ? point.Timestamp.Value.ToUnixTime(precision).ToString() : string.Empty;
         }

--- a/InfluxData.Net.InfluxDb/Models/WriteRequest.cs
+++ b/InfluxData.Net.InfluxDb/Models/WriteRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using InfluxData.Net.Common.Constants;
 using InfluxData.Net.InfluxDb.Formatters;
 
 namespace InfluxData.Net.InfluxDb.Models
@@ -30,7 +31,7 @@ namespace InfluxData.Net.InfluxDb.Models
         /// <summary>
         /// Point data time precision.
         /// </summary>
-        public string Precision { get; set; }
+        public TimeUnit Precision { get; set; }
 
         /// <summary>
         /// Data retention policy.

--- a/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
+++ b/InfluxData.Net.InfluxDb/RequestClients/InfluxDbRequestClient.cs
@@ -9,6 +9,7 @@ using InfluxData.Net.InfluxDb.Infrastructure;
 using InfluxData.Net.InfluxDb.Models;
 using InfluxData.Net.Common.Helpers;
 using InfluxData.Net.Common.Enums;
+using InfluxData.Net.Common.Constants;
 
 namespace InfluxData.Net.InfluxDb.RequestClients
 {
@@ -36,7 +37,7 @@ namespace InfluxData.Net.InfluxDb.RequestClients
         {
             var requestParams = RequestParamsBuilder.BuildRequestParams(
                 writeRequest.DbName,
-                QueryParams.Precision, writeRequest.Precision,
+                QueryParams.Precision, writeRequest.Precision.ToEpochFormat(),
                 QueryParams.RetentionPolicy, writeRequest.RetentionPolicy
             );
             var httpContent = new StringContent(writeRequest.GetLines(), Encoding.UTF8, "text/plain");


### PR DESCRIPTION
Summary 

- Changed TimeUnit to be an enum.
- Added Nanoseconds, Ticks and Microseconds to TimeUnit
- Added TimeUnit formatting extension

Discussion:

Nanoseconds and Ticks are effectively synonyms. The changes make use of the DateTime.AddTicks() function to compute differences from the epoch with a resolution of 100 nanoseconds (1 Tick).

I didn't have the time to go through the tests and see if anything needs adjusting, I only did some actual data ingress with the modified code. It would be wise to review my changes and modify/add tests as required.