### PR TITLE
Add new property "Partial" to the InfluxDB Serie response model.

### DIFF
--- a/InfluxData.Net.InfluxDb/Models/Responses/Serie.cs
+++ b/InfluxData.Net.InfluxDb/Models/Responses/Serie.cs
@@ -32,5 +32,10 @@ namespace InfluxData.Net.InfluxDb.Models.Responses
         /// Serie values.
         /// </summary>
         public IList<IList<object>> Values { get; set; }
+
+        /// <summary>
+        /// Indicates a partial result as described in https://docs.influxdata.com/influxdb/v1.7/administration/config#max-row-limit-0
+        /// </summary>
+        public bool Partial { get; set; }
     }
 }


### PR DESCRIPTION
Partial is a boolean value returned by InfluxDB if a response has been truncated due to chunking or to exceeding a configured max-row-limit in the response.
Adding this property is sufficient to expose the functionality to users of InfluxData.NET. I've tested it successfully with InfluxDB 1.7.6-1
The change is very simple and does not require changing existing code, which is why I'd rather not add another test case for it.